### PR TITLE
Update base image from ubi8 to ubi9

### DIFF
--- a/.konflux/dockerfiles/hub-ui.Dockerfile
+++ b/.konflux/dockerfiles/hub-ui.Dockerfile
@@ -1,6 +1,6 @@
 # --- builder image
-ARG NODEJS_BUILDER=registry.access.redhat.com/ubi8/nodejs-18:latest
-ARG RUNTIME=registry.access.redhat.com/ubi8/nginx-122:latest
+ARG NODEJS_BUILDER=registry.access.redhat.com/ubi9/nodejs-18@sha256:d9ae385958d3db69a4a6db3bae55a60bcf82fad7bb036d92b4137add2c093926
+ARG RUNTIME=registry.access.redhat.com/ubi9/nginx-122@sha256:cdb77f7a9c5c3013b524b9e774fa8c843d16dd85d920429ac02d048cbe804992
 
 FROM $NODEJS_BUILDER AS builder
 


### PR DESCRIPTION
as part of [migrating to rhel8 to rhel9 ](https://issues.redhat.com/browse/SRVKP-4554) updating base image for nginx 
