### PR TITLE
Fix README link to upstream repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `openshift-pipelines/tektoncd-hub` *fork*
 
-This is a "managed" fork of [`tektoncd/hub`](tektoncdhub) that is used in OpenShift Pipelines.
+This is a "managed" fork of [`tektoncd/hub`][tektoncdhub] that is used in OpenShift Pipelines.
 It is merely some patches and automation, and doesn't contains any specific code.
 
 [tektoncdhub]: https://github.com/tektoncd/hub


### PR DESCRIPTION
The README's link to upstream `https://github.com/tektoncd/hub` uses [inline-link](https://github.github.com/gfm/#inline-link) syntax but is intended to be a  [reference-link](https://github.github.com/gfm/#full-reference-link), causing the README's link to be broken. 

This PR corrects the syntax to fix the link