### PR TITLE
remove JAVA_COMMUNITY_DEPENDENCIES from results as it is removed from…

### DIFF
--- a/.tekton/docker-build-ta.yaml
+++ b/.tekton/docker-build-ta.yaml
@@ -95,9 +95,6 @@ spec:
   - description: ""
     name: CHAINS-GIT_COMMIT
     value: $(tasks.clone-repository.results.commit)
-  - description: ""
-    name: JAVA_COMMUNITY_DEPENDENCIES
-    value: $(tasks.build-images.results.JAVA_COMMUNITY_DEPENDENCIES)
   tasks:
   - name: init
     params:


### PR DESCRIPTION
Buildah Task was changed as part of this PR
https://github.com/openshift-pipelines/tektoncd-hub/pull/118

Commit Reference
https://github.com/openshift-pipelines/tektoncd-hub/pull/118/commits/ac7a85c5951fc57f054db8e7190cc88c953e785c

Here is ther migration Document
https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-remote-oci-ta/0.3/MIGRATION.md