### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tektoncd-hub-1-18-api

### DIFF
--- a/.konflux/dockerfiles/api.Dockerfile
+++ b/.konflux/dockerfiles/api.Dockerfile
@@ -29,6 +29,7 @@ LABEL \
     com.redhat.component="openshift-pipelines-hub-api-container" \
     name="openshift-pipelines/pipelines-hub-api-rhel9" \
     version=$VERSION \
+    cpe="cpe:/a:redhat:openshift_pipelines:1.18::el9" \
     summary="Red Hat OpenShift Pipelines Hub API" \
     maintainer="pipelines-extcomm@redhat.com" \
     description="Red Hat OpenShift Pipelines Hub API" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
