### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tektoncd-hub-1-15-ui

### DIFF
--- a/.konflux/dockerfiles/ui.Dockerfile
+++ b/.konflux/dockerfiles/ui.Dockerfile
@@ -49,4 +49,5 @@ LABEL \
     description="Red Hat OpenShift Pipelines Hub UI" \
     io.k8s.display-name="Red Hat OpenShift Pipelines Hub UI" \
     io.k8s.description="Red Hat OpenShift Pipelines Hub UI" \
-    io.openshift.tags="pipelines,tekton,openshift"
+    io.openshift.tags="pipelines,tekton,openshift" \
+    cpe="cpe:/a:redhat:openshift_pipelines:1.15::el8"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
