### PR TITLE
Fix EC violations: migrate from nginx-124 to nginx-126

### DIFF
--- a/.konflux/dockerfiles/ui.Dockerfile
+++ b/.konflux/dockerfiles/ui.Dockerfile
@@ -1,7 +1,7 @@
 # Rebuild trigger: 1.15.4 release 2026-01-19
 # --- builder image
 ARG NODEJS_BUILDER=registry.redhat.io/ubi8/nodejs-18@sha256:77d47e5c63e2a45a5d6a5546b145278f04a1a20fcf01b8a3ffaeb1f49056cf11
-ARG RUNTIME=registry.redhat.io/ubi8/nginx-124@sha256:7d31ac929680a488225801af6f988812700e10adfe7ec6222591a43624e4004b
+ARG RUNTIME=registry.redhat.io/ubi9/nginx-126@sha256:830a7974e450e2ec93f0ca6c3a77e7ac84c2f8f71863e1ddea507ff9ee84074f
 
 FROM $NODEJS_BUILDER AS builder
 
@@ -43,7 +43,7 @@ CMD /usr/bin/start.sh
 
 LABEL \
     com.redhat.component="openshift-pipelines-hub-ui-container" \
-    name="openshift-pipelines/pipelines-hub-ui-rhel8" \
+    name="openshift-pipelines/pipelines-hub-ui-rhel9" \
     version=$VERSION \
     summary="Red Hat OpenShift Pipelines Hub UI" \
     maintainer="pipelines-extcomm@redhat.com" \
@@ -51,5 +51,5 @@ LABEL \
     io.k8s.display-name="Red Hat OpenShift Pipelines Hub UI" \
     io.k8s.description="Red Hat OpenShift Pipelines Hub UI" \
     io.openshift.tags="pipelines,tekton,openshift" \
-    cpe="cpe:/a:redhat:openshift_pipelines:1.15::el8"
+    cpe="cpe:/a:redhat:openshift_pipelines:1.15::el9"
 # trigger rebuild 2026-02-14


### PR DESCRIPTION
## Summary

Fixes Enterprise Contract `deprecated-image-check` violations by migrating Hub UI from deprecated nginx-124 to latest nginx-126 base image.

## Changes

- **Base image:** `ubi8/nginx-124` → `ubi9/nginx-126` (latest stable)
- **Digest:** Fresh digest `sha256:830a7974e450e2ec93f0ca6c3a77e7ac84c2f8f71863e1ddea507ff9ee84074f`
- **Labels:** Updated `rhel8` → `rhel9` and CPE `el8` → `el9` to match new base

## Context

- MintMaker nudge PR #1421 only updated nginx-124 digest but didn't address the deprecation
- nginx-124 is flagged by EC as deprecated
- nginx-126 is the latest stable nginx version in Red Hat UBI
- nginx-126 only available in ubi9 (not ubi8), requiring UBI version migration

## EC Status

Hub UI does NOT have Go dependency CVE issues (oauth2 v0.29.0 already >= v0.27.0 fix threshold). This PR only addresses the nginx base image deprecation.

## Supersedes

- Closes MintMaker nudge PR #1421 (already closed manually)

## Test Plan

- [ ] Konflux build succeeds for ui component
- [ ] Enterprise Contract passes (no deprecated-image-check violations)
- [ ] UI functionality verified (nginx-126 compatible with existing config)